### PR TITLE
Fix gunicorn restart

### DIFF
--- a/src/apis/restart_gunicorn.sh
+++ b/src/apis/restart_gunicorn.sh
@@ -8,13 +8,13 @@ BIND_ADDRESS="0.0.0.0:8000"
 echo "Restarting Gunicorn processes for $APP_NAME"
 
 # Gracefully terminate the old Gunicorn processes
-# pkill -f "gunicorn.*$APP_NAME"
+pkill -f "gunicorn $APP_NAME --bind $BIND_ADDRESS --daemon"
 
 # Wait for a moment to ensure that the resources are freed
 sleep 5
 
 # Start a new Gunicorn daemon
-gunicorn $APP_NAME --bind $BIND_ADDRESS --daemon &
+gunicorn $APP_NAME --bind $BIND_ADDRESS --daemon
 
 echo "Gunicorn restarted for $APP_NAME"
 

--- a/src/apis/test_restart_gunicorn.sh
+++ b/src/apis/test_restart_gunicorn.sh
@@ -2,21 +2,22 @@
 
 export PATH="/home/ubuntu/.local/bin:$PATH"
 # Gunicorn settings
-MAP_APP_NAME="map.wsgi:application"
+APP_NAME="map.wsgi:application"
 BIND_ADDRESS="0.0.0.0:8001"
 
-echo "Restarting Gunicorn processes for $MAP_APP_NAME"
+
+echo "Restarting Gunicorn processes for $APP_NAME"
 
 # Gracefully terminate the old Gunicorn processes
-# pkill -f "gunicorn.*$MAP_APP_NAME"
+pkill -f "gunicorn $APP_NAME --bind $BIND_ADDRESS --daemon"
 
 # Wait for a moment to ensure that the resources are freed
 sleep 5
 
 # Start a new Gunicorn daemon
-gunicorn $MAP_APP_NAME --bind $BIND_ADDRESS --daemon &
+gunicorn $APP_NAME --bind $BIND_ADDRESS --daemon
 
-echo "Gunicorn restarted for $MAP_APP_NAME"
+echo "Gunicorn restarted for $APP_NAME"
 
 #Set the DJANGO_SETTINGS_MODULE Environment Variable
 export DJANGO_SETTINGS_MODULE=map.settings_test


### PR DESCRIPTION
Pkill was previously removed from restart_gunicorn, it was also killing other processes running on other ports. This later caused changes to not reflect in the website as gunicorn was not properly restarted.

This fix ensures pkill only kills the required process either test or prod based on the port number