### PR TITLE
Fix test docker environment

### DIFF
--- a/src/apis/Dockerfile.test
+++ b/src/apis/Dockerfile.test
@@ -18,6 +18,8 @@ EXPOSE 8001
 
 RUN chmod +x /app/entrypoint.sh
 
+ENV DJANGO_SETTINGS_MODULE=map.settings_test
+
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 CMD ["gunicorn", "map.wsgi:application", "--bind", "0.0.0.0:8001"]


### PR DESCRIPTION
Add DJANGO_SETTINGS_MODULE environment variable for test configuration in Dockerfile. This will ensure settings_test.py file is used for running the test environment.